### PR TITLE
fix name of environment variable

### DIFF
--- a/.env.azure-example
+++ b/.env.azure-example
@@ -1,6 +1,6 @@
 OPENAI_API_KEY=XXXX
 OPENAI_API_TYPE=azure
-OPENAI_BASE_URL=https://your-resource-name.openai.azure.com
+OPENAI_API_BASE=https://your-resource-name.openai.azure.com
 OPENAI_API_VERSION=2023-03-15-preview
 # OPENAI_EXTRA_HEADERS={"key": "value"}
 AZURE_OPENAI_DEPLOYMENTS=[{"displayName": "GPT-3.5", "name": "your-gpt-3.5-deployment"}, {"displayName": "GPT-4", "name": "your-gpt-4-deployment"}]

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 OPENAI_API_KEY=sk-XXXX
 OPENAI_API_TYPE=open_ai
-OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_API_BASE=https://api.openai.com/v1
 OPENAI_API_VERSION=2023-03-15-preview
 # OPENAI_EXTRA_HEADERS={"key": "value"}
 OPENAI_MODELS=[{"displayName": "GPT-3.5", "name": "gpt-3.5-turbo"}, {"displayName": "GPT-4", "name": "gpt-4"}]


### PR DESCRIPTION
With a previous change (99a6ba82d504728e41ea6372e342fddf99671039), these variables are read by the openai package automagically and thus should have the correct name